### PR TITLE
Add Snapshot voting power wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ typechain-types
 cache
 artifacts
 .openzeppelin
+.DS_Store

--- a/contracts/SnapshotVotingPower.sol
+++ b/contracts/SnapshotVotingPower.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+interface IHodlerVotingPower {
+    struct LockData {
+        string fingerprint;
+        address operator;
+        uint256 amount;
+    }
+
+    function votesOf(address hodler) external view returns (uint256);
+
+    function getLocks(address hodler)
+        external
+        view
+        returns (LockData[] memory);
+}
+
+contract SnapshotVotingPower {
+    IHodlerVotingPower public immutable hodlerContract;
+
+    constructor(address _hodlerContract) {
+        require(_hodlerContract != address(0), "Invalid Hodler address");
+        hodlerContract = IHodlerVotingPower(_hodlerContract);
+    }
+
+    function votesOf(address hodler) external view returns (uint256) {
+        uint256 votingPower = hodlerContract.votesOf(hodler);
+
+        IHodlerVotingPower.LockData[] memory locks =
+            hodlerContract.getLocks(hodler);
+
+        for (uint256 i = 0; i < locks.length; i++) {
+            votingPower += locks[i].amount;
+        }
+
+        return votingPower;
+    }
+}

--- a/test/SnapshotVotingPower.ts
+++ b/test/SnapshotVotingPower.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai";
+import { ethers, upgrades } from "hardhat";
+
+describe("SnapshotVotingPower", function () {
+  it("returns Hodler votes plus locked tokens", async function () {
+    const [owner, user, controller, rewardsPool, operator] =
+      await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("Token");
+    const token: any = await Token.deploy(
+      ethers.parseEther("100000000")
+    );
+    await token.waitForDeployment();
+
+    const lockSize = ethers.parseEther("100");
+    const oneDay = 24 * 60 * 60;
+
+    const HodlerV5 = await ethers.getContractFactory("HodlerV5");
+    const hodler: any = await upgrades.deployProxy(HodlerV5, [
+      await token.getAddress(),
+      controller.address,
+      lockSize,
+      oneDay * 7,
+      ethers.parseEther("1"),
+      oneDay * 14,
+      oneDay * 30,
+      rewardsPool.address,
+      ethers.parseEther("0.0001"),
+    ]);
+    await hodler.waitForDeployment();
+
+    const SnapshotVotingPower =
+      await ethers.getContractFactory("SnapshotVotingPower");
+
+    const wrapper: any = await SnapshotVotingPower.deploy(
+      await hodler.getAddress()
+    );
+    await wrapper.waitForDeployment();
+
+    await token.transfer(
+      user.address,
+      ethers.parseEther("1000")
+    );
+
+    await token
+      .connect(user)
+      .approve(await hodler.getAddress(), ethers.MaxUint256);
+
+    await hodler
+      .connect(user)
+      .stake(operator.address, ethers.parseEther("50"));
+
+    await hodler.connect(user).becomeVoter();
+
+    await hodler
+      .connect(user)
+      .lock("relay-1", operator.address);
+
+    expect(await hodler.votesOf(user.address)).to.equal(
+      ethers.parseEther("50")
+    );
+
+    expect(await wrapper.votesOf(user.address)).to.equal(
+      ethers.parseEther("150")
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add a Snapshot-compatible voting power wrapper
- Return a user's Hodler voting power plus their locked token amounts
- Add validation for the Hodler contract address
- Add test coverage for combined stake and lock voting power

## Testing

- `npx hardhat test test/SnapshotVotingPower.ts`
- `npx hardhat test`
- 109 tests passing